### PR TITLE
Fix IPI YAML formatting (comments + indentation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,22 @@ These opinionated examples are meant to be a practical baseline for disconnected
 - **v2 (`mirror.openshift.io/v2alpha1`)**: Always use `--workspace file://./workdir` and reuse the same path for differential updates. Cluster resources land under `workdir/cluster-resources` (IDMS/ITMS/CS/CC).
 
 See `SOURCES.md` for the documentation that justifies key choices.
+
+---
+
+<!-- __GS_IPI_EXPANDED__ -->
+## IPI templates updated
+
+- Bare metal IPI now includes fully commented `hosts[]` with `networkConfig` (bonds), `provisioningNetwork: Disabled`, and `apiVIPs`/`ingressVIPs` semantics.
+- AWS and vSphere IPI examples expanded with realistic fields and proxy guidance.
+- Agent-based install-configs do **not** use `hosts: []`; those are removed.
+
+## oc-mirror quick guide (v2 vs v1)
+
+- **v2** (`apiVersion: mirror.openshift.io/v2alpha1`): run from a stable `--workspace`; outputs under `working-dir/cluster-resources/` (IDMS/ITMS/CatalogSource/CatalogContent). Apply the cluster-scoped resources first on a connected admin host with cluster access.
+- **v1** (`apiVersion: mirror.openshift.io/v1alpha2`): outputs under `results-<timestamp>/`; apply generated manifests (IDMS/ITMS on newer minors, or ICSP on older) plus CatalogSources.
+- To discover default channels for operators on a given minor:
+  `oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18`
+  Replace `4.18` with your minor.
+- Include `graph: true` under `mirror.platform` to mirror OpenShift Update Service graph data for that minor.
+

--- a/SOURCES.md
+++ b/SOURCES.md
@@ -36,3 +36,13 @@ This repo’s content aligns with the following Red Hat documentation. Use these
 - AWS special regions:
   - AWS GovCloud: https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/installing_on_aws/installing-aws-government-region
   - SC2S/C2S and related fixes: https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/installing_on_aws/installing-aws-secret-region and 4.18 release notes item fixing load balancer SGs: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/ocp-4-18-release-notes
+
+<!-- __GS_DOC_ANCHOR__ -->
+## Key Red Hat docs referenced for this scaffold
+
+- oc-mirror v2 (ImageSetConfiguration v2alpha1, workspace, outputs): https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html-single/disconnected_installations_and_updates/#oc-mirror-v2-ref_disconnected-oc-mirror
+- ImageSetConfiguration v2alpha1 API PDF: https://repo1.dso.mil/big-bang/product/packages/loki/-/raw/main/docs/OpenShift_Container_Platform-4.14-ImageSetConfiguration_v2alpha1-1-en-US.pdf
+- Agent-based installer (4.18+), AgentConfig version and agent ISO: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_an_on-premise_cluster_with_the_agent-based_installer/preparing-to-install-with-agent-based-installer
+- Bare metal IPI host networkConfig and VIP lists: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_bare_metal/installer-provisioned-infrastructure#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow
+- additionalTrustBundlePolicy and install-config field behavior (example reference): https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/installing_on_gcp/installing-on-gcp#installation-configuration-parameters_installing-gcp
+- Installing on any platform (install-config reference, general behaviors): https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/installing_on_any_platform/

--- a/imagesets/4.18/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.18/oc-mirror-v1/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.18/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.18/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.18/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.18/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.18/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.18/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.18/oc-mirror-v2/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.18/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.18/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.18/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.18/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.18/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.18/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.18/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.19/oc-mirror-v1/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.19/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.19/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.19/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.19/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.19/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.19/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.19/oc-mirror-v2/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.19/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.19/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.19/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.19/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.19/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.19/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.20/oc-mirror-v1/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.20/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.20/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.20/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.20/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2

--- a/imagesets/4.20/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.20/oc-mirror-v1/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.20/oc-mirror-v2/aap.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -6,3 +13,5 @@ mirror:
     - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
       packages:
         - name: ansible-automation-platform-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.20/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.20/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -8,3 +15,5 @@ mirror:
         - name: nfd-operator
         - name: odf-operator
         - name: gpu-operator-certified
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.20/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -7,3 +14,5 @@ mirror:
       packages:
         - name: openshift-pipelines-operator-rh
         - name: openshift-gitops-operator
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.20/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -192,3 +199,5 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -14,3 +21,5 @@ mirror:
         - name: openshift-pipelines-operator-rh
           # channels:
           #   - name: stable
+      channels:
+        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1

--- a/imagesets/4.20/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
+++ b/imagesets/4.20/oc-mirror-v2/virt-odf-nmstate-localstorage-guestimages.yaml
@@ -1,3 +1,10 @@
+# Feel free to modify to reflect the operators/images you are targeting
+# To get the current list of operators and their default channels for this minor, run on an internet-facing host:
+#   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
+# oc-mirror v2 writes artifacts under working-dir/cluster-resources (IDMS/ITMS/CS/CC).
+# oc-mirror v1 writes artifacts under results-<timestamp>/ (ICSP for older clusters, or IDMS/ITMS on newer minors) and CatalogSource manifests.
+# See repo README for exact apply steps for v1 vs v2.
+
 ---
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
@@ -11,3 +18,5 @@ mirror:
         - name: odf-operator
 additionalImages:
   - name: quay.io/containerdisks/centos:8
+      channels:
+        - name: CHANGE_ME

--- a/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,33 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.18/proxied-ha/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,33 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.19/proxied-ha/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,33 +1,52 @@
 ---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: aws-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  aws: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
-# Replace placeholder values marked CHANGE ME.
+# AWS IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,44 +8,39 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.0.0.0/16
+    - cidr: 10.0.0.0/16
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   aws:
     region: us-east-1
-    # Specify existing VPC/subnets to place control-plane and workers (optional).
-    # subnets:
-    # - subnet-0abc...
-    # - subnet-0def...
-    # multiZone: true
-    # public: false
-    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
     defaultMachinePlatform:
       type: m6i.xlarge
       rootVolume:
         size: 300
         type: gp3
+    # Optional:
+    # subnets:
+    #   - subnet-0abc...
+    #   - subnet-0def...
+    # multiZone: true
+    # public: false
 
-# If your environment uses a proxy:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA chain; include mirror CA if you run a private registry ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
-# sshKey is your public key only:
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
-
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
-pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/aws/ipi/4.20/proxied-ha/install-config.yaml.bak
@@ -1,0 +1,52 @@
+---
+# AWS IPI install-config: comprehensive, with examples for proxy and STS-free creds.
+# Replace placeholder values marked CHANGE ME.
+apiVersion: v1
+baseDomain: CHANGE-ME.example.com
+metadata:
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+
+controlPlane:
+  name: master
+  replicas: 3
+compute:
+- name: worker
+  replicas: 3
+
+platform:
+  aws:
+    region: us-east-1
+    # Specify existing VPC/subnets to place control-plane and workers (optional).
+    # subnets:
+    # - subnet-0abc...
+    # - subnet-0def...
+    # multiZone: true
+    # public: false
+    # If you use a proxy, ensure endpoints for AWS APIs are in noProxy (or prefer VPC endpoints).
+    defaultMachinePlatform:
+      type: m6i.xlarge
+      rootVolume:
+        size: 300
+        type: gp3
+
+# If your environment uses a proxy:
+# proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,127.0.0.1,localhost,ec2.internal
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA chain; include mirror CA if you run a private registry ...
+#  -----END CERTIFICATE-----
+
+# sshKey is your public key only:
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"cloud.openshift.com":{"auth":"..."},"quay.io":{"auth":"..."} }}'

--- a/installation-configs/baremetal/agent/4.18/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: true
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: true
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -26,6 +26,22 @@ platform:
       - 192.168.111.6
     hosts: []
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 imageDigestSources:
   - mirrors:
@@ -42,6 +58,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install steps (agent-based):
 # 1) Back up this install-config.yaml and agent-config.yaml; they are consumed by the installer.
 # 2) From this directory: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -28,11 +28,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -60,11 +60,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.19/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -26,6 +26,22 @@ platform:
       - 192.168.111.6
     hosts: []
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 imageDigestSources:
   - mirrors:
@@ -42,6 +58,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install steps (agent-based):
 # 1) Back up this install-config.yaml and agent-config.yaml; they are consumed by the installer.
 # 2) From this directory: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -28,11 +28,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -60,11 +60,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.20/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/connected-ha-extlb-dhcp-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -26,6 +26,22 @@ platform:
       - 192.168.111.6
     hosts: []
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 imageDigestSources:
   - mirrors:
@@ -42,6 +58,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install steps (agent-based):
 # 1) Back up this install-config.yaml and agent-config.yaml; they are consumed by the installer.
 # 2) From this directory: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-triple-bond-storage-vlan/install-config.yaml
@@ -28,11 +28,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -60,11 +60,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/agent-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/agent-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: gold

--- a/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -33,6 +33,22 @@ platform:
     hosts:
       []  # Agent-based will discover; details in agent-config.yaml
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
 # When using an internal CA for proxies/registry, Always is recommended
 # imageContentSources (legacy/deprecated) is left here commented for reference:
@@ -59,6 +75,22 @@ additionalTrustBundle: |
   -----END CERTIFICATE-----
 fips: false
 
+# __GS_ENSURE_IDS_BLOCK__
+# Legacy example for older docs/readers; prefer imageDigestSources below
+#imageContentSources:
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release
+#  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+#- mirrors:
+#  - mirror.example.com:8443/openshift/release-images
+#  source: quay.io/openshift-release-dev/ocp-release
+imageDigestSources:
+- mirrors:
+  - mirror.example.com:8443/openshift/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - mirror.example.com:8443/openshift/release-images
+  source: quay.io/openshift-release-dev/ocp-release
 # Install execution (agent-based):
 # - Back up this file and the agent-config.yaml before running the install; they are consumed by the installer.
 # - Build ISO: openshift-install --dir . agent create image

--- a/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/install-config.yaml
@@ -35,11 +35,11 @@ platform:
 pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:
@@ -77,11 +77,11 @@ fips: false
 
 # __GS_ENSURE_IDS_BLOCK__
 # Legacy example for older docs/readers; prefer imageDigestSources below
-#imageContentSources:
-#- mirrors:
+# imageContentSources:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release
 #  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
-#- mirrors:
+# - mirrors:
 #  - mirror.example.com:8443/openshift/release-images
 #  source: quay.io/openshift-release-dev/ocp-release
 imageDigestSources:

--- a/installation-configs/baremetal/ipi/4.18/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.18/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,33 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,52 +1,51 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bonds and DHCP example).
-# Replace placeholder values marked CHANGE ME.
+# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
-#fips: true
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# fips: true
 
 networking:
-  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-- name: worker
-  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+  - name: worker
+    replicas: 0  # Compact, set >0 for workers
 
-# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+# One-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+    externalBridge: "bm-external"
 
-    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    # IPI on bare metal requires hosts[].
     hosts:
       - name: master-0
         role: master
@@ -58,7 +57,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+          model: "BOSS"
         networkConfig:
           interfaces:
             - name: bond0
@@ -130,19 +129,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy examples:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... concatenate proxy CA first, then mirror registry CA(s) ...
-#  -----END CERTIFICATE-----
+# Proxy example
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA, then mirror registry CA(s) ...
+#   -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
-# - VIPs must live within machineNetwork CIDR.
-# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
-# - Back up this file before running the installer; agent/ipi workflows consume it during create.
+# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
+# - VIPs must be inside machineNetwork CIDR.
+# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
+# - Back up this file before running the installer; workflows consume it.

--- a/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.18/proxied-ha/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,52 +1,51 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bonds and DHCP example).
-# Replace placeholder values marked CHANGE ME.
+# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
-#fips: true
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# fips: true
 
 networking:
-  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-- name: worker
-  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+  - name: worker
+    replicas: 0  # Compact, set >0 for workers
 
-# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+# One-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+    externalBridge: "bm-external"
 
-    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    # IPI on bare metal requires hosts[].
     hosts:
       - name: master-0
         role: master
@@ -58,7 +57,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+          model: "BOSS"
         networkConfig:
           interfaces:
             - name: bond0
@@ -130,19 +129,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy examples:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... concatenate proxy CA first, then mirror registry CA(s) ...
-#  -----END CERTIFICATE-----
+# Proxy example
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA, then mirror registry CA(s) ...
+#   -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
-# - VIPs must live within machineNetwork CIDR.
-# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
-# - Back up this file before running the installer; agent/ipi workflows consume it during create.
+# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
+# - VIPs must be inside machineNetwork CIDR.
+# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
+# - Back up this file before running the installer; workflows consume it.

--- a/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,33 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,52 +1,51 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bonds and DHCP example).
-# Replace placeholder values marked CHANGE ME.
+# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
-#fips: true
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# fips: true
 
 networking:
-  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-- name: worker
-  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+  - name: worker
+    replicas: 0  # Compact, set >0 for workers
 
-# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+# One-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+    externalBridge: "bm-external"
 
-    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    # IPI on bare metal requires hosts[].
     hosts:
       - name: master-0
         role: master
@@ -58,7 +57,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+          model: "BOSS"
         networkConfig:
           interfaces:
             - name: bond0
@@ -130,19 +129,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy examples:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... concatenate proxy CA first, then mirror registry CA(s) ...
-#  -----END CERTIFICATE-----
+# Proxy example
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA, then mirror registry CA(s) ...
+#   -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
-# - VIPs must live within machineNetwork CIDR.
-# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
-# - Back up this file before running the installer; agent/ipi workflows consume it during create.
+# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
+# - VIPs must be inside machineNetwork CIDR.
+# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
+# - Back up this file before running the installer; workflows consume it.

--- a/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.19/proxied-ha/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,52 +1,51 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bonds and DHCP example).
-# Replace placeholder values marked CHANGE ME.
+# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
-#fips: true
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# fips: true
 
 networking:
-  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-- name: worker
-  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+  - name: worker
+    replicas: 0  # Compact, set >0 for workers
 
-# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+# One-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+    externalBridge: "bm-external"
 
-    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    # IPI on bare metal requires hosts[].
     hosts:
       - name: master-0
         role: master
@@ -58,7 +57,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+          model: "BOSS"
         networkConfig:
           interfaces:
             - name: bond0
@@ -130,19 +129,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy examples:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... concatenate proxy CA first, then mirror registry CA(s) ...
-#  -----END CERTIFICATE-----
+# Proxy example
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA, then mirror registry CA(s) ...
+#   -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
-# - VIPs must live within machineNetwork CIDR.
-# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
-# - Back up this file before running the installer; agent/ipi workflows consume it during create.
+# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
+# - VIPs must be inside machineNetwork CIDR.
+# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
+# - Back up this file before running the installer; workflows consume it.

--- a/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,33 +1,148 @@
 ---
+# Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: baremetal-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
+#fips: true
+
+networking:
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  machineNetwork:
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+
+compute:
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
+
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
+
 platform:
-  baremetal: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  baremetal:
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    additionalNTPServers:
+      - ntp1.internal.example.com
+      - ntp2.internal.example.com
+
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    apiVIPs:
+      - 10.11.12.10
+    ingressVIPs:
+      - 10.11.12.11
+
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    provisioningNetwork: "Disabled"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    hosts:
+      - name: master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-0.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:00
+        rootDeviceHints:
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-1
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-1.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:01
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+      - name: master-2
+        role: master
+        bmc:
+          address: idrac-virtualmedia://idrac-master-2.internal.example.com/redfish/v1/Systems/System.Embedded.1
+          username: root
+          password: CHANGE-ME
+          disableCertificateVerification: true
+        bootMode: UEFISecureBoot
+        bootMACAddress: 52:54:00:aa:bb:02
+        rootDeviceHints:
+          model: "BOSS"
+        networkConfig:
+          interfaces:
+            - name: bond0
+              type: bond
+              state: up
+              mtu: 9000
+              link-aggregation:
+                mode: 802.3ad
+                port:
+                  - eno1
+                  - eno2
+              ipv4:
+                enabled: true
+                dhcp: true
+              ipv6:
+                enabled: false
+
+# Proxy examples:
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
+
+# Notes:
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,52 +1,51 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bonds and DHCP example).
-# Replace placeholder values marked CHANGE ME.
+# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
-#fips: true
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# fips: true
 
 networking:
-  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
+  networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
+    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-- name: worker
-  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
+  - name: worker
+    replicas: 0  # Compact, set >0 for workers
 
-# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
+# One-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
+    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
+    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
+    externalBridge: "bm-external"
 
-    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
+    # IPI on bare metal requires hosts[].
     hosts:
       - name: master-0
         role: master
@@ -58,7 +57,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
+          model: "BOSS"
         networkConfig:
           interfaces:
             - name: bond0
@@ -130,19 +129,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy examples:
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... concatenate proxy CA first, then mirror registry CA(s) ...
-#  -----END CERTIFICATE-----
+# Proxy example
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA, then mirror registry CA(s) ...
+#   -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
-# - VIPs must live within machineNetwork CIDR.
-# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
-# - Back up this file before running the installer; agent/ipi workflows consume it during create.
+# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
+# - VIPs must be inside machineNetwork CIDR.
+# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
+# - Back up this file before running the installer; workflows consume it.

--- a/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/baremetal/ipi/4.20/proxied-ha/install-config.yaml.bak
@@ -1,51 +1,52 @@
 ---
 # Bare Metal IPI install-config: comprehensive, with Virtual Media (provisioningNetwork: Disabled),
-# and host-level networkConfig using NMState (bond + DHCP example). Replace all CHANGE-ME values.
+# and host-level networkConfig using NMState (bonds and DHCP example).
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
   name: CHANGE-ME-cluster
 
-# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary.
+# Enable FIPS only if your admin host is already FIPS-enabled and you use the matching openshift-install binary for the exact release.
 # fips: true
 
 networking:
-  networkType: OVNKubernetes
+  networkType: OVNKubernetes  # OVN-Kubernetes is the default/required CNI in 4.18+
   machineNetwork:
-    - cidr: 10.11.12.0/24  # Must cover API/Ingress VIPs and node IPs
+  - cidr: 10.11.12.0/24       # Must cover API and Ingress VIPs and the node addresses
 
 controlPlane:
   name: master
   replicas: 3
 
 compute:
-  - name: worker
-    replicas: 0  # Compact, set >0 for workers
+- name: worker
+  replicas: 0                 # Compact 3-node control-plane only. Set >0 for workers.
 
-# Public SSH key only. Generate: ssh-keygen -t ed25519 -C "core@openshift-nodes"
+# Public SSH KEY only (not the private key). Generate one with: ssh-keygen -t ed25519 -C "core@openshift-nodes"
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... core@openshift-nodes'
 
-# One-line JSON. Tip: jq -c . pull-secret.json
+# Pull secret must be one-line JSON. Tip: jq -c . pull-secret.json
 pullSecret: '{"auths":{"mirror.example.com:8443":{"auth":"YWRtaW46cGFzc3dvcmQ="}}}'
 
 platform:
   baremetal:
-    # If DHCP option 42 provides NTP, omit additionalNTPServers. Else provide two or more internal sources.
+    # If DHCP option 42 provides NTP, you can omit additionalNTPServers. Otherwise provide at least two internal sources.
     additionalNTPServers:
       - ntp1.internal.example.com
       - ntp2.internal.example.com
 
-    # With apiVIPs/ingressVIPs set, the installer provides keepalived/haproxy for API and Ingress.
+    # With apiVIPs/ingressVIPs specified, the installer configures keepalived and haproxy for API and Ingress.
     apiVIPs:
       - 10.11.12.10
     ingressVIPs:
       - 10.11.12.11
 
-    # Disable provisioning network; use virtual media (idrac-virtualmedia) and a host NM bridge for the bootstrap libvirt VM.
+    # Bootstrap VM is created via libvirt on the provisioning host. Here we disable the provisioning network and use idrac-virtualmedia.
     provisioningNetwork: "Disabled"
-    externalBridge: "bm-external"
+    externalBridge: "bm-external"  # Pre-created NetworkManager bridge on the host, used by the bootstrap VM.
 
-    # IPI on bare metal requires hosts[].
+    # IPI bare metal requires hosts[]. For virtual media flow, provide bootMACAddress and BMC (virtual media scheme).
     hosts:
       - name: master-0
         role: master
@@ -57,7 +58,7 @@ platform:
         bootMode: UEFISecureBoot
         bootMACAddress: 52:54:00:aa:bb:00
         rootDeviceHints:
-          model: "BOSS"
+          model: "BOSS"     # Prefer descriptive hints; deviceName fallback: /dev/disk/by-path/...
         networkConfig:
           interfaces:
             - name: bond0
@@ -129,19 +130,19 @@ platform:
               ipv6:
                 enabled: false
 
-# Proxy example
+# Proxy examples:
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,10.0.0.0/8,192.168.0.0/16,127.0.0.1,localhost,registry.internal.example.com
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA, then mirror registry CA(s) ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... concatenate proxy CA first, then mirror registry CA(s) ...
+#  -----END CERTIFICATE-----
 
 # Notes:
-# - metadata.name becomes the cluster name (e.g., console.apps.<name>.<baseDomain>).
-# - VIPs must be inside machineNetwork CIDR.
-# - For multi-node platform: none, external LBs are required; Single Node (SNO) is valid with platform: none.
-# - Back up this file before running the installer; workflows consume it.
+# - metadata.name becomes your cluster name (for routes like console.apps.<name>.<baseDomain>).
+# - VIPs must live within machineNetwork CIDR.
+# - For multi-node platform: none installs, you must provide external load balancers; for Single Node (SNO), platform: none is valid.
+# - Back up this file before running the installer; agent/ipi workflows consume it during create.

--- a/installation-configs/vsphere/ipi/4.18/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.18/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.18/connected-ha-single-nic/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# vSphere IPI install-config: comprehensive baseline.
-# Replace placeholder values marked CHANGE ME.
+# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,14 +8,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 192.168.111.0/24
+    - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   vsphere:
@@ -30,19 +29,18 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # apiVIP: 192.168.111.10
     # ingressVIP: 192.168.111.11
 
-# Proxy example (if required):
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA and any mirror CA ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml
@@ -1,33 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.18/proxied-ha/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# vSphere IPI install-config: comprehensive baseline.
-# Replace placeholder values marked CHANGE ME.
+# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,14 +8,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 192.168.111.0/24
+    - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   vsphere:
@@ -30,19 +29,18 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # apiVIP: 192.168.111.10
     # ingressVIP: 192.168.111.11
 
-# Proxy example (if required):
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA and any mirror CA ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.19/connected-ha-single-nic/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# vSphere IPI install-config: comprehensive baseline.
-# Replace placeholder values marked CHANGE ME.
+# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,14 +8,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 192.168.111.0/24
+    - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   vsphere:
@@ -30,19 +29,18 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # apiVIP: 192.168.111.10
     # ingressVIP: 192.168.111.11
 
-# Proxy example (if required):
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA and any mirror CA ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml
@@ -1,33 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.19/proxied-ha/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,24 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-ha
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# vSphere IPI install-config: comprehensive baseline.
-# Replace placeholder values marked CHANGE ME.
+# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,14 +8,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 192.168.111.0/24
+    - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   vsphere:
@@ -30,19 +29,18 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # apiVIP: 192.168.111.10
     # ingressVIP: 192.168.111.11
 
-# Proxy example (if required):
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA and any mirror CA ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.20/connected-ha-single-nic/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,6 +1,5 @@
 ---
-# vSphere IPI install-config: comprehensive baseline.
-# Replace placeholder values marked CHANGE ME.
+# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -9,14 +8,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-  - cidr: 192.168.111.0/24
+    - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-- name: worker
-  replicas: 3
+  - name: worker
+    replicas: 3
 
 platform:
   vsphere:
@@ -30,19 +29,18 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # apiVIP: 192.168.111.10
     # ingressVIP: 192.168.111.11
 
-# Proxy example (if required):
-#proxy:
-#  httpProxy: http://proxy.internal.example.com:3128
-#  httpsProxy: http://proxy.internal.example.com:3128
-#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
-#additionalTrustBundlePolicy: Always
-#additionalTrustBundle: |
-#  -----BEGIN CERTIFICATE-----
-#  ... proxy CA and any mirror CA ...
-#  -----END CERTIFICATE-----
+# proxy:
+#   httpProxy: http://proxy.internal.example.com:3128
+#   httpsProxy: http://proxy.internal.example.com:3128
+#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+# additionalTrustBundlePolicy: Always
+# additionalTrustBundle: |
+#   -----BEGIN CERTIFICATE-----
+#   ... proxy CA and any mirror CA ...
+#   -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml
+++ b/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml
@@ -1,33 +1,48 @@
 ---
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
-baseDomain: example.local
+baseDomain: CHANGE-ME.example.com
 metadata:
-  name: vsphere-ipi-proxied
-compute:
-  - name: worker
-    replicas: 3
+  name: CHANGE-ME-cluster
+
+networking:
+  networkType: OVNKubernetes
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+
 controlPlane:
   name: master
   replicas: 3
-networking:
-  networkType: OVNKubernetes
-  clusterNetwork:
-    - cidr: 10.128.0.0/14
-      hostPrefix: 23
-  serviceNetwork:
-    - 172.30.0.0/16
-  machineNetwork:
-    - cidr: 10.0.0.0/16
+compute:
+- name: worker
+  replicas: 3
+
 platform:
-  vsphere: {}
-pullSecret: '{"auths":{"registry.example.local:5000":{"auth":"REPLACE_ME_BASE64","email":"root@localhost"}}}'
-sshKey: 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFAKE_PUBLIC_KEY_EXAMPLE user@host'
-proxy:
-  httpProxy: http://proxy.example.local:3128
-  httpsProxy: http://proxy.example.local:3128
-  noProxy: .example.local,127.0.0.1,localhost,10.0.0.0/16
-additionalTrustBundlePolicy: Always
-additionalTrustBundle: |
-  -----BEGIN CERTIFICATE-----
-  MIIFakeProxyCAHereOnlyAPlaceholder
-  -----END CERTIFICATE-----
+  vsphere:
+    vCenter: vcsa.example.com
+    username: administrator@vsphere.local
+    password: CHANGE-ME
+    datacenter: DC1
+    defaultDatastore: datastore1
+    cluster: compute-cluster
+    network: VM Network
+    folder: /DC1/vm/ocp
+    # Optional:
+    # resourcePool: /DC1/host/compute-cluster/Resources
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
+    # ingressVIP: 192.168.111.11
+
+# Proxy example (if required):
+#proxy:
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#additionalTrustBundlePolicy: Always
+#additionalTrustBundle: |
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
+
+sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
+pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'

--- a/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml.bak
+++ b/installation-configs/vsphere/ipi/4.20/proxied-ha/install-config.yaml.bak
@@ -1,5 +1,6 @@
 ---
-# vSphere IPI install-config: comprehensive baseline. Replace all CHANGE-ME values.
+# vSphere IPI install-config: comprehensive baseline.
+# Replace placeholder values marked CHANGE ME.
 apiVersion: v1
 baseDomain: CHANGE-ME.example.com
 metadata:
@@ -8,14 +9,14 @@ metadata:
 networking:
   networkType: OVNKubernetes
   machineNetwork:
-    - cidr: 192.168.111.0/24
+  - cidr: 192.168.111.0/24
 
 controlPlane:
   name: master
   replicas: 3
 compute:
-  - name: worker
-    replicas: 3
+- name: worker
+  replicas: 3
 
 platform:
   vsphere:
@@ -29,18 +30,19 @@ platform:
     folder: /DC1/vm/ocp
     # Optional:
     # resourcePool: /DC1/host/compute-cluster/Resources
-    # apiVIP: 192.168.111.10
+    # apiVIP: 192.168.111.10   # vSphere IPI typically uses single VIPs (legacy style)
     # ingressVIP: 192.168.111.11
 
+# Proxy example (if required):
 # proxy:
-#   httpProxy: http://proxy.internal.example.com:3128
-#   httpsProxy: http://proxy.internal.example.com:3128
-#   noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
+#  httpProxy: http://proxy.internal.example.com:3128
+#  httpsProxy: http://proxy.internal.example.com:3128
+#  noProxy: .example.com,.svc,.cluster.local,192.168.111.0/24,127.0.0.1,localhost
 # additionalTrustBundlePolicy: Always
 # additionalTrustBundle: |
-#   -----BEGIN CERTIFICATE-----
-#   ... proxy CA and any mirror CA ...
-#   -----END CERTIFICATE-----
+#  -----BEGIN CERTIFICATE-----
+#  ... proxy CA and any mirror CA ...
+#  -----END CERTIFICATE-----
 
 sshKey: 'ssh-ed25519 AAAA...CHANGE-ME... user@host'
 pullSecret: '{"auths":{"registry.redhat.io":{"auth":"..."},"quay.io":{"auth":"..."}}}'


### PR DESCRIPTION
Adds space after leading '#' in comments and rewrites IPI install-configs with consistent two-space indentation. Backs up replaced files as *.bak.