### PR TITLE
Virt networking scenarios + fixes + imageset sync

### DIFF
--- a/SOURCES.md
+++ b/SOURCES.md
@@ -46,3 +46,11 @@ This repo’s content aligns with the following Red Hat documentation. Use these
 - Bare metal IPI host networkConfig and VIP lists: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/installing_on_bare_metal/installer-provisioned-infrastructure#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow
 - additionalTrustBundlePolicy and install-config field behavior (example reference): https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/installing_on_gcp/installing-on-gcp#installation-configuration-parameters_installing-gcp
 - Installing on any platform (install-config reference, general behaviors): https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/installing_on_any_platform/
+
+## Virt Secondary Networking
+- Access external networks with OpenShift Virtualization (Red Hat Blog, 2024):
+  https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+- KubeVirt NetworkAttachmentDefinition API reference:
+  https://kubevirt.io/user-guide/operations/network/secondary_networks/
+- SR-IOV Network Operator documentation:
+  https://docs.openshift.com/container-platform/4.18/networking/hardware_networks/installing-sriov-operator.html

--- a/imagesets/4.18/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.18/oc-mirror-v1/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.18/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.18/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.18/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.18/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.18/oc-mirror-v2/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.18/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.18/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.18/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.18/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.18/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.18 --version=4.18

--- a/imagesets/4.19/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.19/oc-mirror-v1/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,8 +11,8 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: ansible-automation-platform-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19

--- a/imagesets/4.19/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.19/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,10 +11,12 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: nfd-operator
-        - name: odf-operator
+          channels:
+            - name: CHANGE_ME
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.19
         - name: gpu-operator-certified
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.19/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,9 +11,11 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: openshift-pipelines-operator-rh
+          channels:
+            - name: CHANGE_ME
         - name: openshift-gitops-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.19/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -199,5 +200,3 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
-      channels:
-        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -19,7 +20,5 @@ mirror:
       # targetCatalog: my-registry.local/redhat/redhat-operator-index
       packages:
         - name: openshift-pipelines-operator-rh
-          # channels:
-          #   - name: stable
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.19/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19

--- a/imagesets/4.19/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.19/oc-mirror-v2/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,8 +11,8 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: ansible-automation-platform-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19

--- a/imagesets/4.19/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.19/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,10 +11,12 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: nfd-operator
-        - name: odf-operator
+          channels:
+            - name: CHANGE_ME
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.19
         - name: gpu-operator-certified
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.19/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -10,9 +11,11 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
       packages:
         - name: openshift-pipelines-operator-rh
+          channels:
+            - name: CHANGE_ME
         - name: openshift-gitops-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.19/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -199,5 +200,3 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
-      channels:
-        - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19
@@ -19,7 +20,5 @@ mirror:
       # targetCatalog: my-registry.local/redhat/redhat-operator-index
       packages:
         - name: openshift-pipelines-operator-rh
-          # channels:
-          #   - name: stable
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.19/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.19/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.19 --version=4.19

--- a/imagesets/4.20/oc-mirror-v1/aap.yaml
+++ b/imagesets/4.20/oc-mirror-v1/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,8 +11,8 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: ansible-automation-platform-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/additional-images-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20

--- a/imagesets/4.20/oc-mirror-v1/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.20/oc-mirror-v1/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,10 +11,12 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: nfd-operator
-        - name: odf-operator
+          channels:
+            - name: CHANGE_ME
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
         - name: gpu-operator-certified
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/cicd-devtools.yaml
+++ b/imagesets/4.20/oc-mirror-v1/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,9 +11,11 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: openshift-pipelines-operator-rh
+          channels:
+            - name: CHANGE_ME
         - name: openshift-gitops-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/golden-all.yaml
+++ b/imagesets/4.20/oc-mirror-v1/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -199,5 +200,3 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
-      channels:
-        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/operators-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -19,7 +20,5 @@ mirror:
       # targetCatalog: my-registry.local/redhat/redhat-operator-index
       packages:
         - name: openshift-pipelines-operator-rh
-          # channels:
-          #   - name: stable
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v1/platform-only.yaml
+++ b/imagesets/4.20/oc-mirror-v1/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20

--- a/imagesets/4.20/oc-mirror-v2/aap.yaml
+++ b/imagesets/4.20/oc-mirror-v2/aap.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,8 +11,8 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: ansible-automation-platform-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/additional-images-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/additional-images-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20

--- a/imagesets/4.20/oc-mirror-v2/ai-gpu-odf-trident.yaml
+++ b/imagesets/4.20/oc-mirror-v2/ai-gpu-odf-trident.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,10 +11,12 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: nfd-operator
-        - name: odf-operator
+          channels:
+            - name: CHANGE_ME
+    - catalog: registry.redhat.io/redhat/certified-operator-index:v4.20
         - name: gpu-operator-certified
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/cicd-devtools.yaml
+++ b/imagesets/4.20/oc-mirror-v2/cicd-devtools.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -10,9 +11,11 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.18
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
       packages:
         - name: openshift-pipelines-operator-rh
+          channels:
+            - name: CHANGE_ME
         - name: openshift-gitops-operator
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/golden-all.yaml
+++ b/imagesets/4.20/oc-mirror-v2/golden-all.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -199,5 +200,3 @@ mirror:
     - name: quay.io/containerdisks/centos:7-2009
     - name: quay.io/containerdisks/centos-stream:8-latest
     - name: quay.io/containerdisks/centos-stream:9-latest
-      channels:
-        - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/operators-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/operators-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20
@@ -19,7 +20,5 @@ mirror:
       # targetCatalog: my-registry.local/redhat/redhat-operator-index
       packages:
         - name: openshift-pipelines-operator-rh
-          # channels:
-          #   - name: stable
-      channels:
-        - name: CHANGE_ME
+          channels:
+            - name: CHANGE_ME

--- a/imagesets/4.20/oc-mirror-v2/platform-only.yaml
+++ b/imagesets/4.20/oc-mirror-v2/platform-only.yaml
@@ -1,3 +1,4 @@
+---
 # Feel free to modify to reflect the operators/images you are targeting
 # To get the current list of operators and their default channels for this minor, run on an internet-facing host:
 #   oc-mirror list operators --catalog=registry.redhat.io/redhat/redhat-operator-index:v4.20 --version=4.20

--- a/installation-configs/baremetal/agent/4.18/connected-ha-extlb-dhcp-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.18/connected-ha-extlb-dhcp-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# connected-ha-extlb-dhcp-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/README.md
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-bond-vlan-fips/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-bond-vlan-fips
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/README.md
+++ b/installation-configs/baremetal/agent/4.18/disconnected-3node-intlb-static-multi-subnet/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-multi-subnet
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/README.md
+++ b/installation-configs/baremetal/agent/4.18/disconnected-ha-intlb-static-bond-vlan/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-ha-intlb-static-bond-vlan
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.18/disconnected-sno-intlb-static-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-sno-intlb-static-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.19/connected-ha-extlb-dhcp-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.19/connected-ha-extlb-dhcp-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# connected-ha-extlb-dhcp-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/README.md
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-bond-vlan-fips/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-bond-vlan-fips
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/README.md
+++ b/installation-configs/baremetal/agent/4.19/disconnected-3node-intlb-static-multi-subnet/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-multi-subnet
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/README.md
+++ b/installation-configs/baremetal/agent/4.19/disconnected-ha-intlb-static-bond-vlan/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-ha-intlb-static-bond-vlan
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.19/disconnected-sno-intlb-static-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-sno-intlb-static-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.20/connected-ha-extlb-dhcp-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.20/connected-ha-extlb-dhcp-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# connected-ha-extlb-dhcp-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/README.md
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-bond-vlan-fips/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-bond-vlan-fips
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/README.md
+++ b/installation-configs/baremetal/agent/4.20/disconnected-3node-intlb-static-multi-subnet/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-3node-intlb-static-multi-subnet
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/README.md
+++ b/installation-configs/baremetal/agent/4.20/disconnected-ha-intlb-static-bond-vlan/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-ha-intlb-static-bond-vlan
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/README.md
+++ b/installation-configs/baremetal/agent/4.20/disconnected-sno-intlb-static-single-nic/README.md
@@ -1,4 +1,4 @@
-# ${scen}
+# disconnected-sno-intlb-static-single-nic
 
 Notes:
 - All examples use OVN-Kubernetes.

--- a/virt-secondary-networking/4.18/bridge-external.yaml
+++ b/virt-secondary-networking/4.18/bridge-external.yaml
@@ -1,0 +1,20 @@
+---
+# Example: Access external networks using Linux bridge
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "bridge",
+      "bridge": "br-external",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          { "address": "198.51.100.10/24", "gateway": "198.51.100.1" }
+        ]
+      }
+    }

--- a/virt-secondary-networking/4.18/macvtap-external.yaml
+++ b/virt-secondary-networking/4.18/macvtap-external.yaml
@@ -1,0 +1,15 @@
+---
+# Example: Access external networks using macvtap (L2 bridge to host NIC)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: kubevirt.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvtap-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "macvtap",
+      "master": "ens3f0",
+      "mode": "bridge"
+    }

--- a/virt-secondary-networking/4.18/sriov-external.yaml
+++ b/virt-secondary-networking/4.18/sriov-external.yaml
@@ -1,0 +1,18 @@
+---
+# Example: Access external networks using SR-IOV (dedicated VF to VM)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-external
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: sriov_netdevice
+  networkNamespace: default
+  ipam: |
+    {
+      "type": "static",
+      "addresses": [
+        { "address": "192.0.2.10/24", "gateway": "192.0.2.1" }
+      ]
+    }

--- a/virt-secondary-networking/4.19/bridge-external.yaml
+++ b/virt-secondary-networking/4.19/bridge-external.yaml
@@ -1,0 +1,20 @@
+---
+# Example: Access external networks using Linux bridge
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "bridge",
+      "bridge": "br-external",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          { "address": "198.51.100.10/24", "gateway": "198.51.100.1" }
+        ]
+      }
+    }

--- a/virt-secondary-networking/4.19/macvtap-external.yaml
+++ b/virt-secondary-networking/4.19/macvtap-external.yaml
@@ -1,0 +1,15 @@
+---
+# Example: Access external networks using macvtap (L2 bridge to host NIC)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: kubevirt.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvtap-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "macvtap",
+      "master": "ens3f0",
+      "mode": "bridge"
+    }

--- a/virt-secondary-networking/4.19/sriov-external.yaml
+++ b/virt-secondary-networking/4.19/sriov-external.yaml
@@ -1,0 +1,18 @@
+---
+# Example: Access external networks using SR-IOV (dedicated VF to VM)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-external
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: sriov_netdevice
+  networkNamespace: default
+  ipam: |
+    {
+      "type": "static",
+      "addresses": [
+        { "address": "192.0.2.10/24", "gateway": "192.0.2.1" }
+      ]
+    }

--- a/virt-secondary-networking/4.20/bridge-external.yaml
+++ b/virt-secondary-networking/4.20/bridge-external.yaml
@@ -1,0 +1,20 @@
+---
+# Example: Access external networks using Linux bridge
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: bridge-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "bridge",
+      "bridge": "br-external",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          { "address": "198.51.100.10/24", "gateway": "198.51.100.1" }
+        ]
+      }
+    }

--- a/virt-secondary-networking/4.20/macvtap-external.yaml
+++ b/virt-secondary-networking/4.20/macvtap-external.yaml
@@ -1,0 +1,15 @@
+---
+# Example: Access external networks using macvtap (L2 bridge to host NIC)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: kubevirt.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvtap-external
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "macvtap",
+      "master": "ens3f0",
+      "mode": "bridge"
+    }

--- a/virt-secondary-networking/4.20/sriov-external.yaml
+++ b/virt-secondary-networking/4.20/sriov-external.yaml
@@ -1,0 +1,18 @@
+---
+# Example: Access external networks using SR-IOV (dedicated VF to VM)
+# Docs: https://www.redhat.com/en/blog/access-external-networks-with-openshift-virtualization
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-external
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: sriov_netdevice
+  networkNamespace: default
+  ipam: |
+    {
+      "type": "static",
+      "addresses": [
+        { "address": "192.0.2.10/24", "gateway": "192.0.2.1" }
+      ]
+    }


### PR DESCRIPTION
Adds virt-secondary networking scenarios (macvtap, SR-IOV, bridge), enforces YAML '---', strips invalid agent 'hosts:' blocks, replaces scen/ver placeholders in READMEs, syncs 4.19/4.20 imagesets from the fixed 4.18 set, and updates SOURCES.md with references to virt networking documentation.