### PR TITLE
Virt secondary networking: three scenarios from blog (NNCP+NAD+VM each)

### DIFF
--- a/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/nad-br1-linux-bridge.yaml
+++ b/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/nad-br1-linux-bridge.yaml
@@ -1,0 +1,15 @@
+---
+# NAD for Option 3 (Linux bridge). Connect directly to 'br1'.
+# No IPAM; configure IP inside the VM if needed.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br1-network
+  namespace: vmtest
+spec:
+  config: '{
+    "cniVersion": "0.3.1",
+    "type": "bridge",
+    "name": "br1-network",
+    "bridge": "br1"
+  }'

--- a/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/nncp-br1-linux-bridge.yaml
+++ b/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/nncp-br1-linux-bridge.yaml
@@ -1,0 +1,22 @@
+---
+# Option 3: Linux bridge 'br1' on a dedicated NIC (no OVN localnet mapping).
+# Safe rollback: change the interface 'state: up' -> 'state: absent' and re-apply the NNCP.
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br1-linux-bridge
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: br1
+        description: Linux bridge with enp8s0 as a port
+        type: linux-bridge
+        state: up
+        bridge:
+          options:
+            stp:
+              enabled: false
+          port:
+            - name: enp8s0  # CHANGE ME to the dedicated NIC on your nodes

--- a/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/vm-br1-linux-bridge-example.yaml
+++ b/openshift-install-configs/virt-secondary-networking/linux-bridge-dedicated-nic/vm-br1-linux-bridge-example.yaml
@@ -1,0 +1,31 @@
+---
+# VM example for Option 3: use the Linux bridge NAD (direct to 'br1')
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-br1-net
+  namespace: vmtest
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        example: br1-linux-bridge
+    spec:
+      networks:
+        - name: br1-net
+          multus:
+            networkName: vmtest/br1-network
+      domain:
+        devices:
+          interfaces:
+            - name: br1-net
+              bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/centos-stream:9-latest

--- a/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/nad-br0-ovs-bridge.yaml
+++ b/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/nad-br0-ovs-bridge.yaml
@@ -1,0 +1,16 @@
+---
+# NAD for Option 2 (OVN localnet on br0).
+# "name" must match NNCP localnet (br0-network). No IPAM for VMs.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br0-network
+  namespace: vmtest
+spec:
+  config: '{
+    "name": "br0-network",
+    "type": "ovn-k8s-cni-overlay",
+    "cniVersion": "0.4.0",
+    "topology": "localnet",
+    "netAttachDefName": "vmtest/br0-network"
+  }'

--- a/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/nncp-br0-ovs-bridge.yaml
+++ b/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/nncp-br0-ovs-bridge.yaml
@@ -1,0 +1,30 @@
+---
+# Option 2: OVS bridge 'br0' on a dedicated NIC, then add an OVN localnet mapping (br0-network).
+# Safe rollback:
+#   - Change the interface 'state' from 'up' to 'absent'
+#   - Change the mapping 'state' from 'present' to 'absent'
+#   - Re-apply this NNCP and wait for 'SuccessfullyConfigured'
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br0-ovs
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    interfaces:
+      - name: br0
+        description: |
+          A dedicated OVS bridge with enp2s0 as a port allowing all VLANs and untagged traffic
+        type: ovs-bridge
+        state: up
+        bridge:
+          options:
+            stp: true
+          port:
+            - name: enp2s0  # CHANGE ME to the unused NIC on your nodes
+    ovn:
+      bridge-mappings:
+        - localnet: br0-network  # this name is referenced by the NAD
+          bridge: br0
+          state: present

--- a/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/vm-br0-ovs-bridge-example.yaml
+++ b/openshift-install-configs/virt-secondary-networking/ovs-bridge-dedicated-nic/vm-br0-ovs-bridge-example.yaml
@@ -1,0 +1,31 @@
+---
+# VM example for Option 2: use the OVN localnet NAD on the dedicated OVS bridge
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-br0-net
+  namespace: vmtest
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        example: br0-ovs-localnet
+    spec:
+      networks:
+        - name: br0-net
+          multus:
+            networkName: vmtest/br0-network
+      domain:
+        devices:
+          interfaces:
+            - name: br0-net
+              bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/centos-stream:9-latest

--- a/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/nad-br-ex-localnet.yaml
+++ b/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/nad-br-ex-localnet.yaml
@@ -1,0 +1,18 @@
+---
+# NAD for Option 1 (OVN localnet on br-ex).
+# IMPORTANT:
+# - "name" below must match the NNCP localnet ("br-ex-network")
+# - "netAttachDefName" is <namespace>/<nad-name> and must match metadata
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: br-ex-network
+  namespace: vmtest
+spec:
+  config: '{
+    "name": "br-ex-network",
+    "type": "ovn-k8s-cni-overlay",
+    "cniVersion": "0.4.0",
+    "topology": "localnet",
+    "netAttachDefName": "vmtest/br-ex-network"
+  }'

--- a/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/nncp-br-ex-localnet.yaml
+++ b/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/nncp-br-ex-localnet.yaml
@@ -1,0 +1,18 @@
+---
+# Option 1: Single NIC — add a localnet to br-ex (OVN-Kubernetes)
+# Do NOT attempt to reconfigure 'br-ex' itself. You only add/remove a localnet mapping.
+# Safe rollback: change 'state: present' -> 'state: absent', then re-apply this NNCP.
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: br-ex-network
+spec:
+  # Target worker nodes (adjust selector to your cluster)
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  desiredState:
+    ovn:
+      bridge-mappings:
+        - localnet: br-ex-network  # this name is referenced by the NAD
+          bridge: br-ex            # OVN's external bridge on each node
+          state: present

--- a/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/vm-br-ex-localnet-example.yaml
+++ b/openshift-install-configs/virt-secondary-networking/single-nic-br-ex-localnet/vm-br-ex-localnet-example.yaml
@@ -1,0 +1,32 @@
+---
+# VM example for Option 1: use the OVN localnet NAD on br-ex
+# Replace the containerDisk image with whatever you actually use (PVC/DataVolume is typical in real clusters).
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-br-ex-net
+  namespace: vmtest
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        example: br-ex-localnet
+    spec:
+      networks:
+        - name: br-ex-net
+          multus:
+            networkName: vmtest/br-ex-network
+      domain:
+        devices:
+          interfaces:
+            - name: br-ex-net
+              bridge: {}
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+      volumes:
+        - name: rootdisk
+          containerDisk:
+            image: quay.io/containerdisks/centos-stream:9-latest


### PR DESCRIPTION
Replaces virt-secondary-networking with three scenario folders aligned to the blog: (1) Single NIC via br-ex (localnet), (2) OVS bridge on a dedicated NIC (+ localnet mapping), (3) Linux bridge on a dedicated NIC (direct). Each scenario includes NNCP, NAD (no IPAM), and a KubeVirt VM example. Comments include safe rollback steps (set state to absent, re-apply NNCP).